### PR TITLE
Must match quasar 1.1.0 exactly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "css-vars-ponyfill": "^1.8.0",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
-    "quasar": "^1.0.0-beta.0"
+    "quasar": "1.1.0"
   },
   "bedrock": {
     "browserDependencies": "all",


### PR DESCRIPTION
keeps quasar from breaking while we figure out less/scss support.