### PR TITLE
Upgrade quasar to version 1.1.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "css-vars-ponyfill": "^1.8.0",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
-    "quasar": "1.1.0"
+    "quasar": "1.1.2"
   },
   "bedrock": {
     "browserDependencies": "all",


### PR DESCRIPTION
Was able to get through a fresh install and was able to see all views on a site afterwards. Click functionality was also working.

Tests:

1. fresh install works
2. all components still display
3. was able to click on buttons
4. was able to login
5. was able to submit a form
6. q-select still works (did not get to try the filter functionality yet)

this was tested in 2 different sites.