### PR TITLE
Update for bedrock-webpack/bedrock-views.

### DIFF
--- a/BrQuasarErrorBase.vue
+++ b/BrQuasarErrorBase.vue
@@ -1,0 +1,14 @@
+<template>
+  <q-page padding>
+    <h3><slot name="title" /></h3>
+    <slot />
+    <slot name="contact" />
+  </q-page>
+</template>
+<script>
+export default {
+  name: 'BrQuasarErrorBase'
+};
+</script>
+<style>
+</style>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Add `webpackChunkName` to dynamic imports.
 - Import CSS for bundler.
+- Load Roboto font via CSS by default.
 
 ## 3.1.1 - 2019-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # bedrock-quasar ChangeLog
 
 ### Changed
+- Update dependencies.
+  - Using latest Quasar 1.x.
 - Add `webpackChunkName` to dynamic imports.
 - Import CSS for bundler.
 - Load Roboto font via CSS by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 ### Removed
 - Overrides unneeded with bedrock-views 7 + bedrock-webpack 3.
 
+### Added
+- Quasar based override for `bedrock-vue` base error page.
+
 ## 3.1.1 - 2019-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Load Firefox polyfill by default. Note that this package **must** be loaded
   before `quasar` for this to work.
 
+### Removed
+- Overrides unneeded with bedrock-views 7 + bedrock-webpack 3.
+
 ## 3.1.1 - 2019-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Add `webpackChunkName` to dynamic imports.
 - Import CSS for bundler.
 - Load Roboto font via CSS by default.
+- Load Firefox polyfill by default. Note that this package **must** be loaded
+  before `quasar` for this to work.
 
 ## 3.1.1 - 2019-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-quasar ChangeLog
 
+### Changed
+- Add `webpackChunkName` to dynamic imports.
+
 ## 3.1.1 - 2019-09-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 - Add `webpackChunkName` to dynamic imports.
+- Import CSS for bundler.
 
 ## 3.1.1 - 2019-09-17
 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,10 @@
 
 Frontend support for the [Quasar Framework][] in Bedrock Web applications
 
+## Usage
+
+**Note**: This module currently must be loaded **before** `quasar` due to a
+specific Firefox patch polyfill. Take care to ensure this loading order and
+avoid dynamic import patterns that could load `quasar` first.
+
 [Quasar Framework]: https://quasar-framework.org/

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@
 /* global CSSStyleDeclaration, document, window */
 'use strict';
 
+// NOTE: This *must* be loaded *before* 'quasar'.
+import 'firefox-iframe-getcomputedstyle';
+
 import 'animate.css';
 import 'quasar/dist/quasar.css';
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@
 import 'animate.css';
 import 'quasar/dist/quasar.css';
 
+import './main.css';
+
 export async function theme({Quasar, brand}) {
   let fn;
   const variables = {};

--- a/index.js
+++ b/index.js
@@ -29,7 +29,9 @@ export async function theme({Quasar, brand}) {
 
     // remove monkey-patch and apply variables
     CSSStyleDeclaration.prototype.setProperty = fn;
-    const cssVars = (await import('css-vars-ponyfill')).default;
+    const cssVars = (await import(
+      /* webpackChunkName: "CssVarsPonyfill" */
+      'css-vars-ponyfill')).default;
     cssVars({variables});
   }
 }
@@ -38,7 +40,9 @@ export async function supportIE11() {
   if(!isIE11()) {
     return;
   }
-  await import('quasar/dist/quasar.ie.polyfills.umd.min.js');
+  await import(
+    /* webpackChunkName: "QuasarIePolyfills" */
+    'quasar/dist/quasar.ie.polyfills.umd.min.js');
 
   // TODO: consider monkey-patching CSSStyleDeclaration.prototype.setProperty
   // here just once -- and then use render fn to call cssVars() when new

--- a/index.js
+++ b/index.js
@@ -12,6 +12,13 @@ import 'quasar/dist/quasar.css';
 
 import './main.css';
 
+import Vue from 'vue';
+import {config} from 'bedrock-vue';
+config.ui.components['br-error-base'] = 'br-quasar-error-base';
+Vue.component('br-quasar-error-base', () => import(
+  /* webpackChunkName: "BrQuasarErrorBase" */
+  './BrQuasarErrorBase.vue'));
+
 export async function theme({Quasar, brand}) {
   let fn;
   const variables = {};

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ export async function supportIE11() {
     return;
   }
   await import(
-    /* webpackChunkName: "QuasarIePolyfills" */
+    /* webpackChunkName: "quasar.ie.polyfills" */
     'quasar/dist/quasar.ie.polyfills.umd.min.js');
 
   // TODO: consider monkey-patching CSSStyleDeclaration.prototype.setProperty

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@
 /* global CSSStyleDeclaration, document, window */
 'use strict';
 
+import 'animate.css';
+import 'quasar/dist/quasar.css';
+
 export async function theme({Quasar, brand}) {
   let fn;
   const variables = {};

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ export async function theme({Quasar, brand}) {
     // remove monkey-patch and apply variables
     CSSStyleDeclaration.prototype.setProperty = fn;
     const cssVars = (await import(
-      /* webpackChunkName: "CssVarsPonyfill" */
+      /* webpackChunkName: "css-vars-ponyfill" */
       'css-vars-ponyfill')).default;
     cssVars({variables});
   }

--- a/main.css
+++ b/main.css
@@ -1,0 +1,4 @@
+/*!
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+@import url('https://fonts.googleapis.com/css?family=Roboto:400,700');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "animate.css": "^3.7.2",
     "css-vars-ponyfill": "^2.1.2",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
-    "quasar": "^1.2.1"
+    "quasar": "^1.2.5"
   },
   "bedrock": {
     "webpack": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "main": "index.js",
   "dependencies": {
     "animate.css": "^3.7.2",
-    "css-vars-ponyfill": "^1.8.0",
+    "css-vars-ponyfill": "^2.0.2",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
     "quasar": "1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "main": "index.js",
   "dependencies": {
     "animate.css": "^3.7.2",
-    "css-vars-ponyfill": "^2.0.2",
+    "css-vars-ponyfill": "^2.1.2",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
-    "quasar": "1.1.0"
+    "quasar": "^1.2.1"
   },
   "bedrock": {
     "browserDependencies": "all",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "animate.css": "^3.7.2",
     "css-vars-ponyfill": "^2.1.2",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
-    "quasar": "^1.2.5"
+    "quasar": "^1.4.0"
+  },
+  "peerDependencies": {
+    "bedrock-vue": "github:digitalbazaar/bedrock-vue#errors"
   },
   "bedrock": {
     "webpack": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "quasar": "^1.4.0"
   },
   "peerDependencies": {
-    "bedrock-vue": "github:digitalbazaar/bedrock-vue#errors"
+    "bedrock-vue": "^2.0.0"
   },
   "bedrock": {
     "webpack": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "SEE LICENSE IN LICENSE.md",
   "main": "index.js",
   "dependencies": {
+    "animate.css": "^3.7.2",
     "css-vars-ponyfill": "^1.8.0",
     "firefox-iframe-getcomputedstyle": "^1.0.0",
     "quasar": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -28,17 +28,6 @@
     "quasar": "^1.2.1"
   },
   "bedrock": {
-    "browserDependencies": "all",
-    "manifest": {
-      "quasar": {
-        "main": "dist/quasar.umd.js",
-        "module": "dist/quasar.umd.js",
-        "style": "dist/quasar.css",
-        "dependencies": {
-          "firefox-iframe-getcomputedstyle": ""
-        }
-      }
-    },
     "webpack": {
       "quasar": {
         "resolve": {


### PR DESCRIPTION
- May need to leave `webpack` branch around until projects are updated.
- This reverts the strict `quasar` version.  That can be changed if needed.  I'm of the opinion that that sort of restriction should happen elsewhere.