### PR TITLE
Allow for options to be passed in on quasar setup.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,12 +14,12 @@ import {defineAsyncComponent} from 'vue';
 
 config.ui.components['br-error-base'] = 'br-quasar-error-base';
 
-export async function initialize({app}) {
+export async function initialize({app, options}) {
   if(typeof Quasar !== 'object') {
     throw new TypeError('"Quasar" must be an object.');
   }
 
-  app.use(Quasar);
+  app.use(Quasar, options);    
 
   // eslint-disable-next-line vue/component-definition-name-casing
   app.component('br-quasar-error-base', defineAsyncComponent(() => import(


### PR DESCRIPTION
Allows for options to be passed along in `initialize` to make use of quasar configuration settings: https://quasar.dev/start/umd/#quasar-config-object

For example, this allows the dark mode option to be set easily in quasar
```js
import * as brQuasar from '@bedrock/quasar';
import * as brVue from '@bedrock/vue';
import Quasar from 'quasar';

brVue.initialize({
  async beforeMount({app}) {
    await brQuasar.initialize({app, options: {
      config: {
        dark: true
      }
    }});
    // create root Vue component
    return App;
  }
});
```